### PR TITLE
Create vision lock screen quiz app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,220 @@
+const steps = Array.from(document.querySelectorAll('.step'));
+const form = document.getElementById('visionForm');
+const nextBtn = document.getElementById('nextBtn');
+const backBtn = document.getElementById('backBtn');
+const progressBar = document.getElementById('progressBar');
+const resultSection = document.getElementById('resultSection');
+const downloadLink = document.getElementById('downloadLink');
+const restartBtn = document.getElementById('restartBtn');
+const preview = document.getElementById('visionPreview');
+const canvas = document.getElementById('visionCanvas');
+
+let currentStep = 0;
+
+const palettes = {
+  sunrise: {
+    gradient: ['#ff9a9e', '#fad0c4'],
+    accent: '#fff0f5',
+  },
+  ocean: {
+    gradient: ['#43cea2', '#185a9d'],
+    accent: '#d6fff2',
+  },
+  midnight: {
+    gradient: ['#1e3c72', '#2a5298'],
+    accent: '#d2dcff',
+  },
+};
+
+const focusGlyph = {
+  career: '🚀',
+  wellness: '🌿',
+  relationships: '💞',
+};
+
+function showStep(index) {
+  steps.forEach((step, i) => {
+    step.toggleAttribute('hidden', i !== index);
+  });
+  backBtn.disabled = index === 0;
+  nextBtn.textContent = index === steps.length - 1 ? 'Build my lock screen' : 'Next';
+  const progress = ((index + 1) / steps.length) * 100;
+  progressBar.style.width = `${progress}%`;
+  steps[index].querySelector('input, textarea')?.focus({ preventScroll: true });
+}
+
+function validateStep(index) {
+  const fields = steps[index].querySelectorAll('input, textarea');
+  for (const field of fields) {
+    if (!field.reportValidity()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+nextBtn.addEventListener('click', () => {
+  if (!validateStep(currentStep)) return;
+
+  if (currentStep === steps.length - 1) {
+    buildVision();
+    return;
+  }
+
+  currentStep += 1;
+  showStep(currentStep);
+});
+
+backBtn.addEventListener('click', () => {
+  if (currentStep === 0) return;
+  currentStep -= 1;
+  showStep(currentStep);
+});
+
+restartBtn.addEventListener('click', () => {
+  resultSection.hidden = true;
+  form.hidden = false;
+  currentStep = 0;
+  form.reset();
+  showStep(currentStep);
+  preview.src = '';
+  downloadLink.href = '';
+  downloadLink.setAttribute('aria-disabled', 'true');
+});
+
+function buildVision() {
+  const formData = new FormData(form);
+  const guidingWord = formData.get('guidingWord');
+  const focus = formData.get('focus');
+  const affirmation = formData.get('affirmation');
+  const paletteKey = formData.get('palette');
+
+  const palette = palettes[paletteKey];
+  if (!palette) return;
+
+  renderCanvas({ guidingWord, focus, affirmation, paletteKey, palette });
+
+  const dataUrl = canvas.toDataURL('image/png');
+  preview.src = dataUrl;
+  downloadLink.href = dataUrl;
+  downloadLink.removeAttribute('aria-disabled');
+
+  form.hidden = true;
+  resultSection.hidden = false;
+  resultSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function renderCanvas({ guidingWord, focus, affirmation, paletteKey, palette }) {
+  const ctx = canvas.getContext('2d');
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+
+  // Background gradient
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, palette.gradient[0]);
+  gradient.addColorStop(1, palette.gradient[1]);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  // Overlay arcs for texture
+  drawAurora(ctx, width, height, paletteKey);
+
+  // Guiding word at top
+  ctx.fillStyle = '#ffffff';
+  ctx.font = 'bold 140px "Manrope", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.shadowColor = 'rgba(0,0,0,0.25)';
+  ctx.shadowBlur = 40;
+  ctx.fillText(guidingWord.toUpperCase(), width / 2, 520);
+
+  ctx.shadowBlur = 0;
+
+  // Focus glyph and label
+  ctx.fillStyle = 'rgba(255,255,255,0.85)';
+  ctx.font = '96px "Manrope", sans-serif';
+  ctx.fillText(focusGlyph[focus] ?? '✨', width / 2, 740);
+
+  ctx.font = 'bold 68px "Manrope", sans-serif';
+  ctx.fillText(formatFocusLabel(focus), width / 2, 860);
+
+  // Affirmation block
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  ctx.font = '48px "Manrope", sans-serif';
+  wrapText(
+    ctx,
+    affirmation,
+    width / 2,
+    1160,
+    width - 400,
+    72
+  );
+
+  // Footer ribbon
+  const ribbonHeight = 320;
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.28)';
+  ctx.fillRect(0, height - ribbonHeight, width, ribbonHeight);
+
+  ctx.fillStyle = palette.accent;
+  ctx.font = 'bold 54px "Manrope", sans-serif';
+  ctx.fillText('Vision in Motion', width / 2, height - 180);
+
+  ctx.font = '36px "Manrope", sans-serif';
+  ctx.fillStyle = 'rgba(255,255,255,0.78)';
+  ctx.fillText('Swipe with intention • Hydrate • Celebrate small wins', width / 2, height - 110);
+}
+
+function drawAurora(ctx, width, height, paletteKey) {
+  const curves = {
+    sunrise: ['rgba(255,255,255,0.18)', 'rgba(255,255,255,0.12)'],
+    ocean: ['rgba(255,255,255,0.16)', 'rgba(255,255,255,0.1)'],
+    midnight: ['rgba(255,255,255,0.14)', 'rgba(255,255,255,0.08)'],
+  };
+
+  const layers = curves[paletteKey] ?? ['rgba(255,255,255,0.16)', 'rgba(255,255,255,0.12)'];
+
+  layers.forEach((color, index) => {
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    const offsetY = 600 + index * 260;
+    ctx.moveTo(0, offsetY);
+    ctx.bezierCurveTo(width * 0.25, offsetY - 180, width * 0.6, offsetY + 120, width, offsetY - 40);
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fill();
+  });
+}
+
+function formatFocusLabel(focus) {
+  switch (focus) {
+    case 'career':
+      return 'Career Momentum';
+    case 'wellness':
+      return 'Wellness Rituals';
+    case 'relationships':
+      return 'Radiant Relationships';
+    default:
+      return 'Aligned Living';
+  }
+}
+
+function wrapText(ctx, text, x, y, maxWidth, lineHeight) {
+  const words = text.split(/\s+/);
+  let line = '';
+  let lineY = y;
+
+  for (let n = 0; n < words.length; n += 1) {
+    const testLine = line + words[n] + ' ';
+    const metrics = ctx.measureText(testLine);
+    if (metrics.width > maxWidth && n > 0) {
+      ctx.fillText(line.trim(), x, lineY);
+      line = words[n] + ' ';
+      lineY += lineHeight;
+    } else {
+      line = testLine;
+    }
+  }
+  ctx.fillText(line.trim(), x, lineY);
+}
+
+showStep(currentStep);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vision Mirror</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="quiz" aria-live="polite">
+        <header class="quiz__header">
+          <h1>Mirror Vision Builder</h1>
+          <p>Create a lock screen that keeps your dream in focus.</p>
+          <div class="progress" role="status" aria-live="polite">
+            <div class="progress__bar" id="progressBar"></div>
+          </div>
+        </header>
+        <form id="visionForm" class="quiz__form">
+          <div class="step" data-step="1">
+            <h2>What is your guiding word for the year?</h2>
+            <p class="hint">Keep it short and powerful.</p>
+            <input
+              type="text"
+              name="guidingWord"
+              placeholder="e.g. Flourish"
+              required
+              maxlength="20"
+            />
+          </div>
+
+          <div class="step" data-step="2" hidden>
+            <h2>Choose a focus area</h2>
+            <p class="hint">We&apos;ll tune the layout to match your vibe.</p>
+            <div class="choices">
+              <label class="choice">
+                <input type="radio" name="focus" value="career" required />
+                <span>Career Momentum</span>
+              </label>
+              <label class="choice">
+                <input type="radio" name="focus" value="wellness" />
+                <span>Wellness Rituals</span>
+              </label>
+              <label class="choice">
+                <input type="radio" name="focus" value="relationships" />
+                <span>Radiant Relationships</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="step" data-step="3" hidden>
+            <h2>Write a short affirmation</h2>
+            <p class="hint">This will sit in the center of your screen.</p>
+            <textarea
+              name="affirmation"
+              rows="3"
+              placeholder="I show up every day for the life I desire."
+              required
+              maxlength="120"
+            ></textarea>
+          </div>
+
+          <div class="step" data-step="4" hidden>
+            <h2>Pick a mood palette</h2>
+            <p class="hint">We match the colors to a subtle gradient.</p>
+            <div class="palettes">
+              <label class="palette">
+                <input type="radio" name="palette" value="sunrise" required />
+                <span class="swatch" style="--start:#ff9a9e; --end:#fad0c4"></span>
+                Sunrise Bloom
+              </label>
+              <label class="palette">
+                <input type="radio" name="palette" value="ocean" />
+                <span class="swatch" style="--start:#43cea2; --end:#185a9d"></span>
+                Ocean Focus
+              </label>
+              <label class="palette">
+                <input type="radio" name="palette" value="midnight" />
+                <span class="swatch" style="--start:#1e3c72; --end:#2a5298"></span>
+                Midnight Muse
+              </label>
+            </div>
+          </div>
+
+          <div class="quiz__actions">
+            <button type="button" class="btn btn--ghost" id="backBtn" disabled>
+              Back
+            </button>
+            <button type="button" class="btn" id="nextBtn">Next</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="result" id="resultSection" hidden>
+        <h2>Your lock screen is ready ✨</h2>
+        <p>Tap the preview to save or use the download button.</p>
+        <div class="preview" id="previewContainer">
+          <canvas id="visionCanvas" width="1290" height="2796" hidden></canvas>
+          <img id="visionPreview" alt="Vision board lock screen preview" />
+        </div>
+        <a id="downloadLink" class="btn" download="vision-lockscreen.png">Download</a>
+        <button type="button" class="btn btn--ghost" id="restartBtn">
+          Make another
+        </button>
+      </section>
+    </main>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,215 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Manrope", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: #080b13;
+  color: #f6f8ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #0e1525, #05070d 60%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 3rem);
+}
+
+.app {
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.quiz,
+.result {
+  background: rgba(16, 20, 35, 0.7);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 32px;
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  box-shadow: 0 20px 60px rgba(5, 7, 13, 0.45);
+}
+
+.quiz__header h1 {
+  font-size: clamp(1.8rem, 2.6vw, 2.6rem);
+  margin-bottom: 0.25rem;
+}
+
+.quiz__header p {
+  margin-top: 0;
+  color: rgba(246, 248, 255, 0.72);
+}
+
+.progress {
+  margin-top: 1.25rem;
+  height: 6px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress__bar {
+  width: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #ff9a9e, #fad0c4);
+  transition: width 220ms ease;
+}
+
+.quiz__form {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.step h2 {
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  margin-bottom: 0.75rem;
+}
+
+.hint {
+  margin: 0 0 1.5rem;
+  color: rgba(246, 248, 255, 0.6);
+  font-size: 0.95rem;
+}
+
+input[type="text"],
+textarea {
+  width: 100%;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: inherit;
+  padding: 1rem 1.25rem;
+  font-size: 1rem;
+  resize: none;
+  transition: border 180ms ease, background 180ms ease;
+}
+
+input[type="text"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.choices,
+.palettes {
+  display: grid;
+  gap: 1rem;
+}
+
+.choice,
+.palette {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  transition: transform 160ms ease, border 160ms ease, background 160ms ease;
+}
+
+.choice:hover,
+.palette:hover,
+.choice:has(input:focus-visible),
+.palette:has(input:focus-visible) {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.32);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.choice input,
+.palette input {
+  accent-color: #ff9a9e;
+  transform: scale(1.2);
+}
+
+.swatch {
+  width: 40px;
+  height: 40px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--start), var(--end));
+  border: 1px solid rgba(255, 255, 255, 0.22);
+}
+
+.quiz__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  color: #1a1b20;
+}
+
+.btn:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 10px 26px rgba(250, 208, 196, 0.25);
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.result {
+  text-align: center;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.preview {
+  aspect-ratio: 9 / 19.5;
+  width: min(320px, 80vw);
+  margin: 0 auto;
+  border-radius: 42px;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12),
+    0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.preview img {
+  width: 100%;
+  border-radius: 32px;
+  display: block;
+}
+
+@media (max-width: 760px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .app {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive multi-step quiz to collect vision board inputs
- generate a 1290x2796 canvas-based iPhone lock screen from quiz answers and surface download link
- style the experience with glassmorphism treatment and palette previews

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68dc67ab95b48326978e34f62ed20375